### PR TITLE
Add commands to bin file

### DIFF
--- a/bin/buildozer.js
+++ b/bin/buildozer.js
@@ -1,6 +1,16 @@
 #!/usr/bin/env node
 
-if (process.argv.includes('build') || process.argv.includes('watch') || process.argv.includes('css') || process.argv.includes('img') || process.argv.includes('js') || process.argv.includes('clean')) {
+function argsInclude(list) {
+  let value = false;
+  list.forEach(item => {
+    if (process.argv.includes(item)) {
+      value = true;
+    }
+  });
+  return value;
+}
+
+if (argsInclude(['build', 'watch', 'css', 'img', 'js', 'clean', 'copy', 'js-concat', 'svg-sprite'])) {
   // Run gulp
   require('../lib/gulp')();
 } else if (process.argv.includes('config')) {

--- a/lib/error.js
+++ b/lib/error.js
@@ -8,7 +8,11 @@ function getErrorMessage() {
   error.push(`- ${chalk.bold('config')}: Export path config`);
   error.push(`- ${chalk.bold('css')}: Compile only the CSS`);
   error.push(`- ${chalk.bold('js')}: Compile only the javascript`);
+  error.push(`- ${chalk.bold('js-concat')}: Merge all .js files in concat folder`);
   error.push(`- ${chalk.bold('img')}: Minify the images`);
+  error.push(`- ${chalk.bold('svg-sprite')}: Generate svg sprite`);
+  error.push(`- ${chalk.bold('clean')}: Clean all destination folders`);
+  error.push(`- ${chalk.bold('copy')}: Copy files defined in .buildozerrc`);
   return chalk.red(`\n${error.join('\n')}`);
 }
 


### PR DESCRIPTION
`buildozer js-concat`, `buildozer svg-sprite`, `buildozer clean` & `buildozer copy` commands were not executable or documented in the error report.