### PR TITLE
Only use plumber on watch

### DIFF
--- a/lib/gulp/css.js
+++ b/lib/gulp/css.js
@@ -18,8 +18,12 @@ function css(cb) {
 
 function cssCompile(src, dest, minified, browserSync = false) {
   let stream = gulp
-    .src(src)
-    .pipe(plumber());
+    .src(src);
+
+  // Prevent errors from aborting task when files are being watched
+  if (process.argv.includes('watch')) {
+    stream = stream.pipe(plumber());
+  }
 
   if (minified) {
     stream = stream

--- a/lib/gulp/image.js
+++ b/lib/gulp/image.js
@@ -20,9 +20,14 @@ function img(cb) {
 // Optimize Images
 function imgCompile(src, dest, browserSync = false) {
   let stream = gulp
-    .src(src)
-    .pipe(plumber())
-    .pipe(newer(dest))
+    .src(src);
+
+  // Prevent errors from aborting task when files are being watched
+  if (process.argv.includes('watch')) {
+    stream = stream.pipe(plumber());
+  }
+
+  stream = stream.pipe(newer(dest))
     .pipe(
       imagemin([
         imagemin.gifsicle({interlaced: true}),
@@ -46,20 +51,25 @@ function imgCompile(src, dest, browserSync = false) {
 
 function svgSprite(src, dest, name, browserSync = false) {
   let stream = gulp
-    .src(src)
-    .pipe(plumber())
-    .pipe(
-      imagemin([
-        imagemin.svgo({
-          plugins: [
-            {
-              removeViewBox: false,
-              collapseGroups: true
-            }
-          ]
-        })
-      ])
-    )
+    .src(src);
+
+  // Prevent errors from aborting task when files are being watched
+  if (process.argv.includes('watch')) {
+    stream = stream.pipe(plumber());
+  }
+
+  stream = stream.pipe(
+    imagemin([
+      imagemin.svgo({
+        plugins: [
+          {
+            removeViewBox: false,
+            collapseGroups: true
+          }
+        ]
+      })
+    ])
+  )
     .pipe(gulpSvgSprite({
       svg: {
         xmlDeclaration: false,

--- a/lib/gulp/js.js
+++ b/lib/gulp/js.js
@@ -19,11 +19,16 @@ function js(cb) {
 
 function jsCompile(src, dest, minified, browserSync = false) {
   let stream = gulp
-    .src(src)
-    .pipe(plumber())
-    .pipe(babel({
-      presets: [presetEnv]
-    }));
+    .src(src);
+
+  // Prevent errors from aborting task when files are being watched
+  if (process.argv.includes('watch')) {
+    stream = stream.pipe(plumber());
+  }
+
+  stream = stream.pipe(babel({
+    presets: [presetEnv]
+  }));
 
   if (minified) {
     stream = stream.pipe(terser());
@@ -36,8 +41,14 @@ function jsCompile(src, dest, minified, browserSync = false) {
 
 // eslint-disable-next-line max-params
 function jsConcat(src, dest, name, minified, browserSync = false) {
-  let stream = gulp.src(src)
-    .pipe(plumber())
+  let stream = gulp.src(src);
+
+  // Prevent errors from aborting task when files are being watched
+  if (process.argv.includes('watch')) {
+    stream = stream.pipe(plumber());
+  }
+
+  stream = stream.pipe(plumber())
     .pipe(babel({
       presets: [presetEnv]
     }))


### PR DESCRIPTION
Only `buildozer watch` shouldn't return exit code 1 when a task fails.