### PR TITLE
Modify tasks to use process.env.NODE_ENV convention

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -26,9 +26,9 @@ function watchFiles() {
 
     // eslint-disable-next-line func-names
     gulp.watch(src, function css() {
-      return cssCompile({src, dest, minified: false, browserSync});
+      return cssCompile({src, dest, browserSync});
     });
-    cssCompile({src, dest, minified: false});
+    cssCompile({src, dest});
   });
 
   config.js.forEach(js => {
@@ -37,9 +37,9 @@ function watchFiles() {
 
     // eslint-disable-next-line func-names
     gulp.watch(src, function js() {
-      return jsCompile({src, dest, minified: false, browserSync});
+      return jsCompile({src, dest, browserSync});
     });
-    jsCompile({src, dest, minified: false});
+    jsCompile({src, dest});
   });
 
   config['js-concat'].forEach(js => {
@@ -49,9 +49,9 @@ function watchFiles() {
 
     // eslint-disable-next-line func-names
     gulp.watch(src, function concat() {
-      return jsConcat({src, dest, name, minified: false, browserSync});
+      return jsConcat({src, dest, name, browserSync});
     });
-    jsConcat({src, dest, name, minified: false});
+    jsConcat({src, dest, name});
   });
 
   config.img.forEach(img => {
@@ -91,8 +91,13 @@ function watchFiles() {
   }
 }
 
+function setProduction(cb) {
+  process.env.NODE_ENV = 'production';
+  cb();
+}
+
 // Define complex tasks
-const build = gulp.series(clean, copy, gulp.parallel(css, js, img));
+const build = gulp.series(setProduction, clean, copy, gulp.parallel(css, js, img));
 const watch = gulp.series(clean, copy, watchFiles);
 
 // Export tasks
@@ -103,5 +108,6 @@ exports.js = js;
 exports['js-concat'] = jsConcat;
 exports['svg-sprite'] = svgSprite;
 exports.clean = clean;
+exports.setProduction = setProduction;
 exports.build = build;
 exports.watch = watch;

--- a/lib/gulp/css.js
+++ b/lib/gulp/css.js
@@ -17,14 +17,14 @@ function css(cb) {
   cb();
 }
 
-async function getPostCSSConfiguration(minified) {
+async function getPostCSSConfiguration() {
   try {
     // Get PostCSS config from user
     return await loadPostCSSConfig();
   } catch (error) {
     // Catch no config found from postcss-load-config in order to set default
     // values for our PostCSS instance.
-    if (minified) {
+    if (process.env.NODE_ENV === 'production') {
       return {plugins: [rfs(), autoprefixer(), cssnano()]};
     }
 
@@ -32,8 +32,8 @@ async function getPostCSSConfiguration(minified) {
   }
 }
 
-async function cssCompile({src, dest, minified = true, browserSync = false}) {
-  const {plugins, options = {}} = await getPostCSSConfiguration(minified);
+async function cssCompile({src, dest, browserSync = false}) {
+  const {plugins, options = {}} = await getPostCSSConfiguration();
   let stream = gulp
     .src(src);
 
@@ -42,7 +42,7 @@ async function cssCompile({src, dest, minified = true, browserSync = false}) {
     stream = stream.pipe(plumber());
   }
 
-  if (minified) {
+  if (process.env.NODE_ENV === 'production') {
     stream = stream
       .pipe(sass({outputStyle: 'compressed'}))
       .pipe(postcss(plugins, options));

--- a/lib/gulp/js.js
+++ b/lib/gulp/js.js
@@ -17,7 +17,7 @@ function js(cb) {
   cb();
 }
 
-function jsCompile({src, dest, minified = true, browserSync = false}) {
+function jsCompile({src, dest, browserSync = false}) {
   let stream = gulp
     .src(src);
 
@@ -30,7 +30,7 @@ function jsCompile({src, dest, minified = true, browserSync = false}) {
     presets: [presetEnv]
   }));
 
-  if (minified) {
+  if (process.env.NODE_ENV === 'production') {
     stream = stream.pipe(terser());
   }
 
@@ -39,7 +39,7 @@ function jsCompile({src, dest, minified = true, browserSync = false}) {
   return browserSync === false ? stream : stream.pipe(browserSync.stream({match: '**/*.js'}));
 }
 
-function jsConcat({src, dest, name, minified = true, browserSync = false}) {
+function jsConcat({src, dest, name, browserSync = false}) {
   let stream = gulp.src(src);
 
   // Prevent errors from aborting task when files are being watched
@@ -53,7 +53,7 @@ function jsConcat({src, dest, name, minified = true, browserSync = false}) {
     }))
     .pipe(concat(name));
 
-  if (minified) {
+  if (process.env.NODE_ENV === 'production') {
     stream = stream.pipe(terser());
   }
 


### PR DESCRIPTION
This would allows user to use the context in for example a PostCSS config (#19).

```javascript
module.exports = (ctx) => {
    return {
        plugins: [
            require('rfs')(),
            require('postcss-inline-svg')(),
            require('autoprefixer')(),
            ctx.env === 'production' ? require('cssnano')() : false,
        ]
    }
};
```

Thoughts?