### PR TITLE
Converted long parameter function to destructed parameters object.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -26,9 +26,9 @@ function watchFiles() {
 
     // eslint-disable-next-line func-names
     gulp.watch(src, function css() {
-      return cssCompile(src, dest, false, browserSync);
+      return cssCompile({src, dest, minified: false, browserSync});
     });
-    cssCompile(src, dest, false);
+    cssCompile({src, dest, minified: false});
   });
 
   config.js.forEach(js => {
@@ -37,9 +37,9 @@ function watchFiles() {
 
     // eslint-disable-next-line func-names
     gulp.watch(src, function js() {
-      return jsCompile(src, dest, false, browserSync);
+      return jsCompile({src, dest, minified: false, browserSync});
     });
-    jsCompile(src, dest, false);
+    jsCompile({src, dest, minified: false});
   });
 
   config['js-concat'].forEach(js => {
@@ -49,9 +49,9 @@ function watchFiles() {
 
     // eslint-disable-next-line func-names
     gulp.watch(src, function concat() {
-      return jsConcat(src, dest, name, false, browserSync);
+      return jsConcat({src, dest, name, minified: false, browserSync});
     });
-    jsConcat(src, dest, name, false);
+    jsConcat({src, dest, name, minified: false});
   });
 
   config.img.forEach(img => {
@@ -60,9 +60,9 @@ function watchFiles() {
 
     // eslint-disable-next-line func-names
     gulp.watch(src, function img() {
-      return imgCompile(src, dest, browserSync);
+      return imgCompile({src, dest, browserSync});
     });
-    imgCompile(src, dest);
+    imgCompile({src, dest});
   });
 
   config['svg-sprite'].forEach(js => {
@@ -72,9 +72,9 @@ function watchFiles() {
 
     // eslint-disable-next-line func-names
     gulp.watch(src, function svgSpriteCreate() {
-      return svgSprite(src, dest, name, browserSync);
+      return svgSprite({src, dest, name, browserSync});
     });
-    svgSprite(src, dest, name);
+    svgSprite({src, dest, name});
   });
 
   if (browserSync !== false) {

--- a/lib/gulp/css.js
+++ b/lib/gulp/css.js
@@ -11,12 +11,12 @@ const config = require('./config.js');
 // CSS task
 function css(cb) {
   config.scss.forEach(scss => {
-    cssCompile(config.src_base_path + scss.src, config.dest_base_path + scss.dest, true);
+    cssCompile({src: config.src_base_path + scss.src, dest: config.dest_base_path + scss.dest});
   });
   cb();
 }
 
-function cssCompile(src, dest, minified, browserSync = false) {
+function cssCompile({src, dest, minified = true, browserSync = false}) {
   let stream = gulp
     .src(src);
 

--- a/lib/gulp/image.js
+++ b/lib/gulp/image.js
@@ -9,16 +9,16 @@ const config = require('./config.js');
 // CSS task
 function img(cb) {
   config.img.forEach(img => {
-    imgCompile(config.src_base_path + img.src, config.dest_base_path + img.dest);
+    imgCompile({src: config.src_base_path + img.src, dest: config.dest_base_path + img.dest});
   });
   config['svg-sprite'].forEach(svg => {
-    svgSprite(config.src_base_path + svg.src, config.dest_base_path + svg.dest, svg.name);
+    svgSprite({src: config.src_base_path + svg.src, dest: config.dest_base_path + svg.dest, name: svg.name});
   });
   cb();
 }
 
 // Optimize Images
-function imgCompile(src, dest, browserSync = false) {
+function imgCompile({src, dest, browserSync = false}) {
   let stream = gulp
     .src(src);
 
@@ -49,7 +49,7 @@ function imgCompile(src, dest, browserSync = false) {
   return browserSync === false ? stream : stream.pipe(browserSync.stream({match: '**/*.{png,jpg,jpeg,gif,svg}'}));
 }
 
-function svgSprite(src, dest, name, browserSync = false) {
+function svgSprite({src, dest, name, browserSync = false}) {
   let stream = gulp
     .src(src);
 

--- a/lib/gulp/js.js
+++ b/lib/gulp/js.js
@@ -8,16 +8,16 @@ const config = require('./config.js');
 
 function js(cb) {
   config.js.forEach(js => {
-    jsCompile(config.src_base_path + js.src, config.dest_base_path + js.dest, true);
+    jsCompile({src: config.src_base_path + js.src, dest: config.dest_base_path + js.dest});
   });
 
   config['js-concat'].forEach(js => {
-    jsConcat(config.src_base_path + js.src, config.dest_base_path + js.dest, js.name, true);
+    jsConcat({src: config.src_base_path + js.src, dest: config.dest_base_path + js.dest, name: js.name});
   });
   cb();
 }
 
-function jsCompile(src, dest, minified, browserSync = false) {
+function jsCompile({src, dest, minified = true, browserSync = false}) {
   let stream = gulp
     .src(src);
 
@@ -40,7 +40,7 @@ function jsCompile(src, dest, minified, browserSync = false) {
 }
 
 // eslint-disable-next-line max-params
-function jsConcat(src, dest, name, minified, browserSync = false) {
+function jsConcat({src, dest, name, minified = true, browserSync = false}) {
   let stream = gulp.src(src);
 
   // Prevent errors from aborting task when files are being watched


### PR DESCRIPTION
Sorry for the pull request spams.. :D

If you have functions with a few parameters it's more flexible to destruct them. This allows users to be flexible in which parameter they want to pass in.

Let's say you have this function
```javascript
// normal parameters
function jsConcat(src, dest, name, minified = true, browserSync = false) {
  //...
}
// destructed parameters
function jsConcat({src, dest, name, minified = true, browserSync = false}) {
  //...
}
```
If we use the normal parameters  I have to explicitly pass minified again even though there is a default value.
```javascript
jsConcat('src/path', 'dest/path', 'name', false, true);
```

I can omit the minified parameter as it has a default value. Also the readability is better as the parameters names are instantly visible
```javascript
jsConcat({src: 'src/path', dest: 'dest/path', name: 'name', browserSync: true});
```