### PR TITLE
Remove `eslint-disable-next-line max-params`

### DIFF
--- a/lib/gulp/js.js
+++ b/lib/gulp/js.js
@@ -39,7 +39,6 @@ function jsCompile({src, dest, minified = true, browserSync = false}) {
   return browserSync === false ? stream : stream.pipe(browserSync.stream({match: '**/*.js'}));
 }
 
-// eslint-disable-next-line max-params
 function jsConcat({src, dest, name, minified = true, browserSync = false}) {
   let stream = gulp.src(src);
 


### PR DESCRIPTION
CI tests were not enabled when https://github.com/Intracto/buildozer/pull/24 was merged, thus this issue was not found