### PR TITLE
Use promises for callbacks

### DIFF
--- a/lib/gulp/css.js
+++ b/lib/gulp/css.js
@@ -10,11 +10,12 @@ const plumber = require('gulp-plumber');
 const config = require('./config.js');
 
 // CSS task
-function css(cb) {
-  config.scss.forEach(scss => {
-    cssCompile({src: config.src_base_path + scss.src, dest: config.dest_base_path + scss.dest});
+function css() {
+  const tasks = config.scss.map(scss => {
+    return cssCompile({src: config.src_base_path + scss.src, dest: config.dest_base_path + scss.dest});
   });
-  cb();
+
+  return Promise.all(tasks);
 }
 
 async function getPostCSSConfiguration() {

--- a/lib/gulp/image.js
+++ b/lib/gulp/image.js
@@ -7,14 +7,16 @@ const plumber = require('gulp-plumber');
 const config = require('./config.js');
 
 // CSS task
-function img(cb) {
-  config.img.forEach(img => {
-    imgCompile({src: config.src_base_path + img.src, dest: config.dest_base_path + img.dest});
+function img() {
+  const imgTasks = config.img.map(img => {
+    return imgCompile({src: config.src_base_path + img.src, dest: config.dest_base_path + img.dest});
   });
-  config['svg-sprite'].forEach(svg => {
-    svgSprite({src: config.src_base_path + svg.src, dest: config.dest_base_path + svg.dest, name: svg.name});
+
+  const spriteTasks = config['svg-sprite'].map(svg => {
+    return svgSprite({src: config.src_base_path + svg.src, dest: config.dest_base_path + svg.dest, name: svg.name});
   });
-  cb();
+
+  return Promise.all(imgTasks.concat(spriteTasks));
 }
 
 // Optimize Images

--- a/lib/gulp/js.js
+++ b/lib/gulp/js.js
@@ -6,15 +6,16 @@ const gulp = require('gulp');
 const plumber = require('gulp-plumber');
 const config = require('./config.js');
 
-function js(cb) {
-  config.js.forEach(js => {
-    jsCompile({src: config.src_base_path + js.src, dest: config.dest_base_path + js.dest});
+function js() {
+  const jsTasks = config.js.map(js => {
+    return jsCompile({src: config.src_base_path + js.src, dest: config.dest_base_path + js.dest});
   });
 
-  config['js-concat'].forEach(js => {
-    jsConcat({src: config.src_base_path + js.src, dest: config.dest_base_path + js.dest, name: js.name});
+  const jsConcatTasks = config['js-concat'].map(js => {
+    return jsConcat({src: config.src_base_path + js.src, dest: config.dest_base_path + js.dest, name: js.name});
   });
-  cb();
+
+  return Promise.all(jsTasks.concat(jsConcatTasks));
 }
 
 function jsCompile({src, dest, browserSync = false}) {


### PR DESCRIPTION
Fixes https://github.com/Intracto/buildozer/issues/22. The main tasks now return a promise of all subtasks instead of directly calling the callback function.