### PR TITLE
Fix js & img tasks from logging being finished before actually being finished

### DIFF
--- a/lib/gulp/image.js
+++ b/lib/gulp/image.js
@@ -4,6 +4,7 @@ const newer = require('gulp-newer');
 const gulpSvgSprite = require('gulp-svg-sprite');
 const gulp = require('gulp');
 const plumber = require('gulp-plumber');
+const merge = require('merge-stream');
 const config = require('./config.js');
 
 // CSS task
@@ -16,7 +17,7 @@ function img() {
     return svgSprite({src: config.src_base_path + svg.src, dest: config.dest_base_path + svg.dest, name: svg.name});
   });
 
-  return Promise.all(imgTasks.concat(spriteTasks));
+  return merge(imgTasks.concat(spriteTasks));
 }
 
 // Optimize Images

--- a/lib/gulp/js.js
+++ b/lib/gulp/js.js
@@ -4,6 +4,7 @@ const presetEnv = require('@babel/preset-env');
 const concat = require('gulp-concat');
 const gulp = require('gulp');
 const plumber = require('gulp-plumber');
+const merge = require('merge-stream');
 const config = require('./config.js');
 
 function js() {
@@ -15,7 +16,7 @@ function js() {
     return jsConcat({src: config.src_base_path + js.src, dest: config.dest_base_path + js.dest, name: js.name});
   });
 
-  return Promise.all(jsTasks.concat(jsConcatTasks));
+  return merge(jsTasks.concat(jsConcatTasks));
 }
 
 function jsCompile({src, dest, browserSync = false}) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8806,6 +8806,11 @@
         }
       }
     },
+    "merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
+    },
     "merge2": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.4.tgz",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "gulp-svg-sprite": "^1.5.0",
     "gulp-terser": "^1.2.0",
     "js-yaml": "^3.13.1",
+    "merge-stream": "^2.0.0",
     "postcss-load-config": "^2.1.0",
     "rfs": "^9.0.0",
     "rimraf": "^3.0.0",


### PR DESCRIPTION
This is actually also a fix for #22, but for the `js` and `img` tasks.

**Before**
- `js` & `img` duration times are incorrect
- `js` & `img` seemed to be finished before they are completed (`gulp-imagemin` outputs after `build` task)
```
[14:08:14] Working directory changed to ~/workspace/buildozer
[14:08:17] Using gulpfile ~/workspace/buildozer/gulpfile.js
[14:08:17] Starting 'build'...
[14:08:17] Starting 'clean'...
[14:08:17] Finished 'clean' after 7.52 ms
[14:08:17] Starting 'copy'...
          Files copied:
          - /Users/martijn.cuppens/workspace/buildozer-test/copy/file.txt to
            /Users/martijn.cuppens/workspace/buildozer-test/dest/file.txt
[14:08:17] Finished 'copy' after 61 ms
[14:08:17] Starting 'css'...
[14:08:17] Starting 'js'...
[14:08:17] Starting 'img'...
[14:08:17] Finished 'js' after 92 ms
[14:08:17] Finished 'img' after 92 ms
[14:08:17] gulp-imagemin: Minified 0 images
[14:08:17] Finished 'css' after 337 ms
[14:08:17] Finished 'build' after 410 ms
[14:08:21] gulp-imagemin: Minified 3 images (saved 200 kB - 14.4%)
✨  Done in 7.64s.
```

**After**
- Timings are correct
- Logging happens in the correct order
```
[14:37:35] Working directory changed to ~/workspace/buildozer
[14:37:36] Using gulpfile ~/workspace/buildozer/gulpfile.js
[14:37:36] Starting 'build'...
[14:37:36] Starting 'setProduction'...
[14:37:36] Finished 'setProduction' after 650 μs
[14:37:36] Starting 'clean'...
[14:37:36] Finished 'clean' after 6.38 ms
[14:37:36] Starting 'copy'...
          Files copied:
          - /Users/martijn.cuppens/workspace/buildozer-test/copy/file.txt to
            /Users/martijn.cuppens/workspace/buildozer-test/dest/file.txt
[14:37:36] Finished 'copy' after 27 ms
[14:37:36] Starting 'css'...
[14:37:36] Starting 'js'...
[14:37:36] Starting 'img'...
[14:37:36] gulp-imagemin: Minified 0 images
[14:37:36] Finished 'js' after 309 ms
[14:37:36] Finished 'css' after 316 ms
[14:37:40] gulp-imagemin: Minified 3 images (saved 200 kB - 14.4%)
[14:37:40] Finished 'img' after 4.1 s
[14:37:40] Finished 'build' after 4.14 s
✨  Done in 5.52s.
```