### PR TITLE
Remove dest_base_path in watch task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -68,7 +68,7 @@ function watchFiles() {
   config['svg-sprite'].forEach(js => {
     const src = config.src_base_path + js.src;
     const dest = config.dest_base_path + js.dest;
-    const name = config.dest_base_path + js.name;
+    const { name } = js;
 
     // eslint-disable-next-line func-names
     gulp.watch(src, function svgSpriteCreate() {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -45,7 +45,7 @@ function watchFiles() {
   config['js-concat'].forEach(js => {
     const src = config.src_base_path + js.src;
     const dest = config.dest_base_path + js.dest;
-    const name = js.name;
+    const {name} = js;
 
     // eslint-disable-next-line func-names
     gulp.watch(src, function concat() {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -68,7 +68,7 @@ function watchFiles() {
   config['svg-sprite'].forEach(js => {
     const src = config.src_base_path + js.src;
     const dest = config.dest_base_path + js.dest;
-    const { name } = js;
+    const {name} = js;
 
     // eslint-disable-next-line func-names
     gulp.watch(src, function svgSpriteCreate() {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -45,7 +45,7 @@ function watchFiles() {
   config['js-concat'].forEach(js => {
     const src = config.src_base_path + js.src;
     const dest = config.dest_base_path + js.dest;
-    const name = config.dest_base_path + js.name;
+    const name = js.name;
 
     // eslint-disable-next-line func-names
     gulp.watch(src, function concat() {


### PR DESCRIPTION
Fixes a bug in the watch task that added the destination base path to the name of the file