### PR TITLE
Split unit tests from linting

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,4 +1,4 @@
-name: Unit tests
+name: Linting
 on: [pull_request]
 
 jobs:
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [8, 10, 12]
+        node: [12]
 
     steps:
       - name: Clone repository
@@ -26,8 +26,5 @@ jobs:
       - name: Install npm dependencies
         run: npm ci
 
-      - name: Run tests
-        run: npm run unit-tests
-
-      - name: Check if generated files are up to date
-        run: npm run diff-check
+      - name: Run linting
+        run: npm run lint

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "xo": "^0.25.3"
   },
   "scripts": {
-    "test": "npm-run-all lint tests",
-    "tests": "npm-run-all test-* --parallel",
+    "test": "npm-run-all lint unit-tests",
+    "unit-tests": "npm-run-all test-* --parallel",
     "lint": "xo",
     "test-default": "cd test/default && node ../../bin/buildozer build",
     "test-copy": "cd test/copy && node ../../bin/buildozer build",


### PR DESCRIPTION
Linting of the Buildozer package should only work on the latest LTS node version, we develop on latest LTS anyway.

This should fix this failed test: https://github.com/Intracto/buildozer/pull/111/checks?check_run_id=443391482