### PR TITLE
Config rule per extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,10 +137,22 @@ Buildozer uses a `.buildozerrc` configuration file which uses the yaml syntax an
 src_base_path: ./
 dest_base_path: ./
 scss:
+  - src: scss/**/*.css
+    dest: dest/css
   - src: scss/**/*.scss
     dest: dest/css
+  - src: scss/**/*.sass
+    dest: dest/css
 img:
-  - src: img/**/*.{png,jpg,jpeg,gif,svg}
+  - src: img/**/*.png
+    dest: dest/img
+  - src: img/**/*.jpg
+    dest: dest/img
+  - src: img/**/*.jpeg
+    dest: dest/img
+  - src: img/**/*.gif
+    dest: dest/img
+  - src: img/**/*.svg
     dest: dest/img
 js:
   - src: js/**/*.js

--- a/lib/.buildozerrc
+++ b/lib/.buildozerrc
@@ -1,10 +1,22 @@
 src_base_path: ./
 dest_base_path: ./
 scss:
+  - src: scss/**/*.css
+    dest: dest/css
   - src: scss/**/*.scss
     dest: dest/css
+  - src: scss/**/*.sass
+    dest: dest/css
 img:
-  - src: img/**/*.{png,jpg,jpeg,gif,svg}
+  - src: img/**/*.png
+    dest: dest/img
+  - src: img/**/*.jpg
+    dest: dest/img
+  - src: img/**/*.jpeg
+    dest: dest/img
+  - src: img/**/*.gif
+    dest: dest/img
+  - src: img/**/*.svg
     dest: dest/img
 js:
   - src: js/**/*.js

--- a/lib/gulp/css.js
+++ b/lib/gulp/css.js
@@ -87,16 +87,22 @@ function cssCompile({src, dest, cwd, browserSync = false}) {
           .pipe(gulpIf(file => process.argv.includes('--fix') && file._contents.toString('utf8') !== file.original, gulp.dest(file => file._base))); // Update fixed version differs
       }
 
-      if (process.env.NODE_ENV === 'production') {
-        stream = stream
-          .pipe(sass({outputStyle: 'compressed', fiber}))
-          .pipe(postcss(plugins, options));
-      } else {
-        stream = stream
-          .pipe(sourcemaps.init())
-          .pipe(sass({outputStyle: 'expanded'}))
-          .pipe(postcss(plugins, options))
-          .pipe(sourcemaps.write('.'));
+      // Init sourcemaps
+      if (process.env.NODE_ENV !== 'production') {
+        stream = stream.pipe(sourcemaps.init());
+      }
+
+      // We better check for .scss and .sass extentions, but use this for backwards compatibility with <= v0.3.1
+      if (!src.endsWith('.css')) {
+        stream = stream.pipe(sass({outputStyle: 'expanded', fiber}));
+      }
+
+      // Apply PostCSS plugins
+      stream = stream.pipe(postcss(plugins, options));
+
+      // Write sourcemaps
+      if (process.env.NODE_ENV !== 'production') {
+        stream = stream.pipe(sourcemaps.write('.'));
       }
 
       stream = stream.pipe(gulp.dest(dest));

--- a/lib/gulp/image.js
+++ b/lib/gulp/image.js
@@ -38,21 +38,46 @@ function imgCompile({src, dest, browserSync = false}) {
         stream = stream.pipe(plumber());
       }
 
-      stream = stream.pipe(newer(dest))
-        .pipe(
-          imagemin([
-            imagemin.gifsicle({interlaced: true}),
-            imagemin.mozjpeg({progressive: true}),
-            imagemin.optipng({optimizationLevel: 5}),
-            imagemin.svgo({
+      const extension = src.split('.').pop();
+
+      const plugins = (() => {
+        switch (extension) {
+          case 'gif':
+            return imagemin.gifsicle({interlaced: true});
+          case 'png':
+            return imagemin.optipng({optimizationLevel: 5});
+          case 'svg':
+            return imagemin.svgo({
               plugins: [
                 {
                   removeViewBox: false,
                   collapseGroups: true
                 }
               ]
-            })
-          ], {
+            });
+          case 'jpg':
+          case 'jpeg':
+            return imagemin.mozjpeg({progressive: true});
+          default: // Required for backwards compatibility with <= v0.3.1
+            return [
+              imagemin.gifsicle({interlaced: true}),
+              imagemin.mozjpeg({progressive: true}),
+              imagemin.optipng({optimizationLevel: 5}),
+              imagemin.svgo({
+                plugins: [
+                  {
+                    removeViewBox: false,
+                    collapseGroups: true
+                  }
+                ]
+              })
+            ];
+        }
+      })();
+
+      stream = stream.pipe(newer(dest))
+        .pipe(
+          imagemin([plugins], {
             silent: true
           })
         );
@@ -60,7 +85,7 @@ function imgCompile({src, dest, browserSync = false}) {
       stream = stream.pipe(gulp.dest(dest));
 
       if (browserSync !== false) {
-        stream = stream.pipe(browserSync.stream({match: '**/*.{png,jpg,jpeg,gif,svg}'}));
+        stream = stream.pipe(browserSync.stream({match: `**/*.${extension}`}));
       }
 
       stream.on('end', resolve);

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "unit-tests": "npm-run-all test-* --parallel",
     "lint": "xo",
     "test-default": "cd test/default && node ../../bin/buildozer build",
+    "test-css": "cd test/css && node ../../bin/buildozer build",
     "test-env": "cd test/env && node ../../bin/buildozer build --env=development",
     "test-copy": "cd test/copy && node ../../bin/buildozer build",
     "test-sass-module": "cd test/sass-module && node ../../bin/buildozer build",

--- a/test/config-search/nested/dest/css/main.css
+++ b/test/config-search/nested/dest/css/main.css
@@ -1,1 +1,5 @@
-body{background:red;appearance:none;font-size:1.25rem}
+body {
+  background: red;
+  appearance: none;
+  font-size: 1.25rem;
+}

--- a/test/css/.buildozerrc
+++ b/test/css/.buildozerrc
@@ -1,0 +1,12 @@
+src_base_path: ./
+dest_base_path: ./
+img: []
+js: []
+js-concat: []
+svg-sprite: []
+browsersync:
+  server: null # Static sites
+  proxy: null # Dynamic sites
+  reload: null # Glob to watch for reload
+config_search:
+  enabled: false

--- a/test/css/dest/css/main.css
+++ b/test/css/dest/css/main.css
@@ -1,0 +1,1 @@
+select{-webkit-appearance:none;-moz-appearance:none;appearance:none}

--- a/test/css/scss/main.css
+++ b/test/css/scss/main.css
@@ -1,0 +1,4 @@
+select {
+  /* Comment */
+  appearance: none;
+}


### PR DESCRIPTION
In the config file, the `{png,jpg,jpeg,gif,svg}` patterns are seperated into multiple items in the array. This way, eg `.png` files won't be compiled when source `.svg` files are changed in the watch. Also, this makes it easier to add plugins to specific extensions.

Support for `.css` and `.sass` is also added. It looks a bit weird to have them under the `scss` key in the config, but this will soon change with https://github.com/Intracto/buildozer/issues/17.