### PR TITLE
fixes #174 use process.env.INIT_CWD

### DIFF
--- a/lib/gulp/configs.js
+++ b/lib/gulp/configs.js
@@ -10,8 +10,8 @@ function getConfig(path) {
 
 function watchConfigPaths(paths, name, cwd) {
   const dirs = [cwd];
-  if (cwd !== process.env.PWD) {
-    dirs.push(process.env.PWD);
+  if (cwd !== process.env.INIT_CWD) {
+    dirs.push(process.env.INIT_CWD);
   }
 
   dirs.forEach(dir => {
@@ -63,7 +63,7 @@ async function configs() {
   // Get the default config from the buildozer package
   const baseConfig = getConfig(require.resolve('./../../lib/.buildozerrc'));
   // Merge default config with the config of the current dir if present
-  const config = [processConfig({...baseConfig, ...getConfig(process.env.PWD)}, process.env.PWD)];
+  const config = [processConfig({...baseConfig, ...getConfig(process.env.INIT_CWD)}, process.env.INIT_CWD)];
 
   // Search for configs if config_search is enabled
   if (config[0].config_search.enabled) {


### PR DESCRIPTION
use process.env.INIT_CWD instead of process.env.PWD as this is set by NPM and Yarn regardless of the OS your are running.

fixes #174