### PR TITLE
Mark 'fibers' package as optional dependency

### DIFF
--- a/lib/gulp/sass.js
+++ b/lib/gulp/sass.js
@@ -4,7 +4,6 @@ const PluginError = require('plugin-error');
 const through = require('through2');
 const path = require('path');
 const applySourceMap = require('vinyl-sourcemaps-apply');
-const fiber = require('fibers');
 
 const PLUGIN_NAME = 'gulp-sass';
 
@@ -32,7 +31,16 @@ const gulpSass = () => through.obj((file, enc, cb) => {
   // We set the file path here so that libsass can correctly resolve import paths
   options.file = file.path;
   options.outputStyle = 'expanded';
-  options.fiber = fiber;
+
+  // We speed up sass by adding the fibers package.
+  // See also: https://github.com/sass/dart-sass#javascript-api
+  try {
+    options.fiber = require('fibers');
+  } catch {
+    // The fibers package doesn't always work on node 10.
+    // It isn't required, it just speeds things up.
+    // If the package can't be required, we just ignore the error.
+  }
 
   // Ensure `indentedSyntax` is true if a `.sass` file
   if (path.extname(file.path) === '.sass') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4449,7 +4449,8 @@
     "detect-libc": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+      "optional": true
     },
     "detect-newline": {
       "version": "2.1.0",
@@ -6282,6 +6283,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/fibers/-/fibers-5.0.0.tgz",
       "integrity": "sha512-UpGv/YAZp7mhKHxDvC1tColrroGRX90sSvh8RMZV9leo+e5+EkRVgCEZPlmXeo3BUNQTZxUaVdLskq1Q2FyCPg==",
+      "optional": true,
       "requires": {
         "detect-libc": "^1.0.3"
       }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "copyfiles": "^2.4.1",
     "cosmiconfig": "^7.0.0",
     "fancy-log": "^1.3.3",
-    "fibers": "^5.0.0",
     "glob": "^7.1.6",
     "gulp": "^4.0.2",
     "gulp-babel": "^8.0.0",
@@ -42,6 +41,9 @@
     "update-notifier": "^5.1.0",
     "vinyl-sourcemaps-apply": "^0.2.1",
     "yargs": "^16.2.0"
+  },
+  "optionalDependencies": {
+    "fibers": "^5.0.0"
   },
   "devDependencies": {
     "npm-run-all": "^4.1.5",


### PR DESCRIPTION
The fibers package doesn't always work on node 10. It isn't required, it just speeds things up.

If the package can't be required, it ignores the error and continues compiling sass.