### PR TITLE
Make compatible with node 16 by removing fibers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [10, 12, 14]
+        node: [10, 12, 14, 16]
 
     steps:
       - name: Clone repository

--- a/lib/gulp/sass.js
+++ b/lib/gulp/sass.js
@@ -4,7 +4,6 @@ const PluginError = require('plugin-error');
 const through = require('through2');
 const path = require('path');
 const applySourceMap = require('vinyl-sourcemaps-apply');
-const fiber = require('fibers');
 
 const PLUGIN_NAME = 'gulp-sass';
 
@@ -32,7 +31,6 @@ const gulpSass = () => through.obj((file, enc, cb) => {
   // We set the file path here so that libsass can correctly resolve import paths
   options.file = file.path;
   options.outputStyle = 'expanded';
-  options.fiber = fiber;
 
   // Ensure `indentedSyntax` is true if a `.sass` file
   if (path.extname(file.path) === '.sass') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4446,11 +4446,6 @@
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
       "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc="
     },
-    "detect-libc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
-    },
     "detect-newline": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
@@ -6277,14 +6272,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.0.tgz",
       "integrity": "sha512-aN3pcx/DSmtyoovUudctc8+6Hl4T+hI9GBBHLjA76jdZl7+b1sgh5g4k+u/GL3dTy1/pnYzKp69FpJ0OicE3Wg=="
-    },
-    "fibers": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/fibers/-/fibers-5.0.0.tgz",
-      "integrity": "sha512-UpGv/YAZp7mhKHxDvC1tColrroGRX90sSvh8RMZV9leo+e5+EkRVgCEZPlmXeo3BUNQTZxUaVdLskq1Q2FyCPg==",
-      "requires": {
-        "detect-libc": "^1.0.3"
-      }
     },
     "figures": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "copyfiles": "^2.4.1",
     "cosmiconfig": "^7.0.0",
     "fancy-log": "^1.3.3",
-    "fibers": "^5.0.0",
     "glob": "^7.1.6",
     "gulp": "^4.0.2",
     "gulp-babel": "^8.0.0",


### PR DESCRIPTION
This completely removes the 'fibers' package - which is not required for SASS to work.

The fibers package is not compatible with node 16, and also sometimes fails to work on node 10. It also requires stuff like node-gyp and build tools, which just makes it harder to install.

Because it doesn't have a lot of benefits and it is giving problems, I think it's better if this package is removed.

This MR also adds a test for node 16 to prove it works.

-----

To use this patch in your project already, see #287.