### PR TITLE
[v0] Make compatible with node 16 by removing fibers

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@master
 
       - name: Set Node.js version
-        uses: actions/setup-node@v1.1.0
+        uses: actions/setup-node@v2
         with:
           version: ${{ matrix.node }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,14 +9,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [8, 10, 12]
+        node: [8, 10, 12, 14, 16]
 
     steps:
       - name: Clone repository
         uses: actions/checkout@master
 
       - name: Set Node.js version
-        uses: actions/setup-node@v1.1.0
+        uses: actions/setup-node@v2
         with:
           version: ${{ matrix.node }}
 

--- a/lib/gulp/css.js
+++ b/lib/gulp/css.js
@@ -10,7 +10,6 @@ const sass = require('gulp-sass');
 const gulp = require('gulp');
 const gulpIf = require('gulp-if');
 const plumber = require('gulp-plumber');
-const fiber = require('fibers');
 const configs = require('./configs.js');
 const through = require('through2');
 
@@ -97,7 +96,7 @@ function cssCompile({src, dest, cwd, browserSync = false}) {
 
       // We better check for .scss and .sass extentions, but use this for backwards compatibility with <= v0.3.1
       if (!src.endsWith('.css')) {
-        stream = stream.pipe(sass({outputStyle: 'expanded', fiber}));
+        stream = stream.pipe(sass({outputStyle: 'expanded'}));
       }
 
       // Apply PostCSS plugins

--- a/package-lock.json
+++ b/package-lock.json
@@ -4748,11 +4748,6 @@
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
       "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc="
     },
-    "detect-libc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
-    },
     "detect-newline": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
@@ -6579,14 +6574,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.0.tgz",
       "integrity": "sha512-aN3pcx/DSmtyoovUudctc8+6Hl4T+hI9GBBHLjA76jdZl7+b1sgh5g4k+u/GL3dTy1/pnYzKp69FpJ0OicE3Wg=="
-    },
-    "fibers": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/fibers/-/fibers-5.0.0.tgz",
-      "integrity": "sha512-UpGv/YAZp7mhKHxDvC1tColrroGRX90sSvh8RMZV9leo+e5+EkRVgCEZPlmXeo3BUNQTZxUaVdLskq1Q2FyCPg==",
-      "requires": {
-        "detect-libc": "^1.0.3"
-      }
     },
     "figures": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "cosmiconfig": "^7.0.0",
     "cssnano": "^5.0.2",
     "fancy-log": "^1.3.3",
-    "fibers": "^5.0.0",
     "glob": "^7.1.7",
     "gulp": "^4.0.2",
     "gulp-babel": "^8.0.0",


### PR DESCRIPTION
Same as #281 but for v0.

use `npm i buildozer@github:bartlangelaan/buildozer#v0-test-node-16-and-fibers`.